### PR TITLE
Fix camera bug

### DIFF
--- a/AK_ATV_Simulator/Assets/DemoTools/CameraController.cs
+++ b/AK_ATV_Simulator/Assets/DemoTools/CameraController.cs
@@ -9,6 +9,18 @@ public class CameraController : MonoBehaviour
   {
   }
 
+  void FixedUpdate()
+  {
+    // make sure the camera is above the terrain
+    float min_camera_height = Terrain.activeTerrain.SampleHeight(transform.position)
+      + Terrain.activeTerrain.transform.position.y
+      + 1.5f;
+    float current_camera_height = transform.position.y;
+    if (current_camera_height < min_camera_height)
+    {
+      transform.Translate(0, 0.05f, 0);
+    }
+  }
   // Update is called once per frame
   void Update()
   {

--- a/AK_ATV_Simulator/Assets/VehicleSimulator/ControllerKeyboard.cs
+++ b/AK_ATV_Simulator/Assets/VehicleSimulator/ControllerKeyboard.cs
@@ -25,6 +25,14 @@ public class ControllerKeyboard : MonoBehaviour
             if (Input.GetKey ("a")) { rotate=-1.0f; }
             if (Input.GetKey ("d")) { rotate=+1.0f; }
             vehicle.complementary_filter(0.01f,ref vehicle.cur_steer,rotate);
+
+            // Reset (after flip)
+            if (Input.GetKey("r")) {
+                vehicle.transform.position=vehicle.flat_Y(vehicle.transform.position);
+                vehicle.transform.LookAt(vehicle.flat_Y(vehicle.transform.position+transform.forward*10.0f));
+                vehicle.get_rb().velocity=Vector3.ClampMagnitude(vehicle.get_rb().velocity,5.0f); // limit linear velocity (don't zero it, for ice)
+                vehicle.get_rb().angularVelocity=new Vector3(0.0f,0.0f,0.0f);
+            }
         }
     }
 }

--- a/AK_ATV_Simulator/Assets/VehicleSimulator/VehicleProperties.cs
+++ b/AK_ATV_Simulator/Assets/VehicleSimulator/VehicleProperties.cs
@@ -115,7 +115,7 @@ public class VehicleProperties : MonoBehaviour
         return false;
     }
 
-    Rigidbody get_rg() {
+    Rigidbody get_rb() {
         return rb;
     }
 

--- a/AK_ATV_Simulator/Assets/VehicleSimulator/VehicleProperties.cs
+++ b/AK_ATV_Simulator/Assets/VehicleSimulator/VehicleProperties.cs
@@ -115,6 +115,10 @@ public class VehicleProperties : MonoBehaviour
         return false;
     }
 
+    Rigidbody get_rg() {
+        return rb;
+    }
+
     // Average across the nforce_copies of idx in this array
     /*
     T force_average<T>(T[] force_arr,int idx) {
@@ -262,13 +266,5 @@ public class VehicleProperties : MonoBehaviour
         vehicle_position = rb.transform.localPosition;
         driver_last_position = driver.transform.position;
         driver_last_velocity = driver_velocity; // making our own velocity since the rigidbody isn't updating with respect to the physics engine
-
-        // Reset (after flip)
-        if (Input.GetKey("r")) {
-            transform.position=flat_Y(transform.position);
-            transform.LookAt(flat_Y(transform.position+transform.forward*10.0f));
-            rb.velocity=Vector3.ClampMagnitude(rb.velocity,5.0f); // limit linear velocity (don't zero it, for ice)
-            rb.angularVelocity=new Vector3(0.0f,0.0f,0.0f);
-        }
     }
 }

--- a/AK_ATV_Simulator/Assets/VehicleSimulator/VehicleProperties.cs
+++ b/AK_ATV_Simulator/Assets/VehicleSimulator/VehicleProperties.cs
@@ -115,7 +115,7 @@ public class VehicleProperties : MonoBehaviour
         return false;
     }
 
-    Rigidbody get_rb() {
+    public Rigidbody get_rb() {
         return rb;
     }
 


### PR DESCRIPTION
In CameraController.cs
  Add a check for camera height vs terrain height and move camera up if camera is below some height above the terrain.

In ControllerKeyboard.cs
  Add a check for if 'r' is pressed and reset the vehicle.

In VehicleProperties.cs
  Remove check if 'r' is pressed.
  add getter for RigidBody rb.